### PR TITLE
Check if source path exists before trigging the move

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ class FileManagerPlugin {
                           if (this.options.verbose) {
                             console.log(
                               `  - FileManagerPlugin: Start copy source: ${
-                                command.source
+                              command.source
                               } to destination: ${destination}`,
                             );
                           }
@@ -183,37 +183,39 @@ class FileManagerPlugin {
               return;
             }
 
-            commandOrder.push(
-              () =>
-                new Promise((resolve, reject) => {
-                  if (this.options.verbose) {
-                    console.log(
-                      `  - FileManagerPlugin: Start move source: ${command.source} to destination: ${
-                        command.destination
-                      }`,
-                    );
-                  }
-
-                  mv(command.source, command.destination, { mkdirp: this.options.moveWithMkdirp }, err => {
-                    if (err) {
-                      if (this.options.verbose) {
-                        console.log("  - FileManagerPlugin: Error - move failed", err);
-                      }
-                      reject(err);
-                    }
-
+            if (fs.existsSync(command.source)) {
+              commandOrder.push(
+                () =>
+                  new Promise((resolve, reject) => {
                     if (this.options.verbose) {
                       console.log(
-                        `  - FileManagerPlugin: Finished move source: ${command.source} to destination: ${
-                          command.destination
+                        `  - FileManagerPlugin: Start move source: ${command.source} to destination: ${
+                        command.destination
                         }`,
                       );
                     }
 
-                    resolve();
-                  });
-                }),
-            );
+                    mv(command.source, command.destination, { mkdirp: this.options.moveWithMkdirp }, err => {
+                      if (err) {
+                        if (this.options.verbose) {
+                          console.log("  - FileManagerPlugin: Error - move failed", err);
+                        }
+                        reject(err);
+                      }
+
+                      if (this.options.verbose) {
+                        console.log(
+                          `  - FileManagerPlugin: Finished move source: ${command.source} to destination: ${
+                          command.destination
+                          }`,
+                        );
+                      }
+
+                      resolve();
+                    });
+                  }),
+              );
+            }
           }
 
           break;

--- a/src/index.js
+++ b/src/index.js
@@ -216,6 +216,9 @@ class FileManagerPlugin {
                   }),
               );
             }
+            else {
+              process.emitWarning('  - FileManagerPlugin: Could not move ' + command.source + ': path does not exist')
+            }
           }
 
           break;


### PR DESCRIPTION
### Purpose
 
While running a webpack dev server, moving files would trigger an uncaught exception because the source file path didn't exist. The move would only work upon running creating a build.

This PR adds a check to first see if the file path exists before issuing the file move

The only con about this is that if the file path doesn't exist, it will just silently fail, so perhaps there's an easier way to only run `mv` if we're not in a live webpack server environment. Maybe pass a warning and don't fail the compile?