### PR TITLE
fix: totally async serial executes each function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,12 @@ class FileManagerPlugin {
     }
 
     if (operationList.length) {
-      operationList.reduce((previous, fn) => {
-        return previous.then(retVal => fn(retVal)).catch(err => console.log(err));
+      return operationList.reduce((previous, fn) => {
+        return previous
+          .then(retVal => fn(retVal))
+          .catch(err => {
+            throw err
+          });
       }, Promise.resolve());
     }
   }
@@ -135,12 +139,14 @@ class FileManagerPlugin {
       that.fileHash = compilation.hash;
 
       try {
-        that.checkOptions('onEnd');
+        that.checkOptions('onEnd')
+          .then(() => cb())
+          .catch(err => {
+            throw err
+          });
       } catch (error) {
         compilation.errors.push(error);
       }
-
-      cb();
     };
 
     if (compiler.hooks) {


### PR DESCRIPTION
when i use `archive` within `onEnd` event, the `node-archiver` is not finished  its processing but the hooks `cb()` be called and webpack callback be called later, that was out of my expectation.what i want is each action all be done in webpack `after-emit` hook whatever async or sync processing.

so i opened this repo and made a PR for that, thanks.