### PR TITLE
Support using a glob to find a file and output the file

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -38,7 +38,9 @@ test.serial('should successfully copy when { source: "/source/**/*", destination
 
 test.serial('should successfully copy a file when using a glob pattern { source: "/source/**/*", destination: "/dest" } provided', t => {
 
-  const result = fs.existsSync("./testing/testingglob.js");
+  // NOTE: using `statSync` instead of `existsSync` since it returns true for
+  // both files _and_ directories. Explicitly checking for a file (not directory).
+  const result = fs.statSync("./testing/testingglob.js").isFile();
   t.true(result);
   t.pass();
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -36,6 +36,14 @@ test.serial('should successfully copy when { source: "/source/**/*", destination
 
 });
 
+test.serial('should successfully copy a file when using a glob pattern { source: "/source/**/*", destination: "/dest" } provided', t => {
+
+  const result = fs.existsSync("./testing/testingglob.js");
+  t.true(result);
+  t.pass();
+
+});
+
 test.serial('should successfully copy and create destination directory { source: "/source", destination: "/dest/doesnt-exist-yet" } provided', t => {
 
   const result = fs.existsSync("./testing/testing3");

--- a/tests/webpack-3/webpack.config.js
+++ b/tests/webpack-3/webpack.config.js
@@ -20,6 +20,7 @@ const plainConfig = {
       onEnd: {
         copy: [
            { source: "./dist/*", destination: "./testing/testing1" },
+           { source: "./dist/*.js", destination: "./testing/testingglob.js" },
            { source: "./dist/**/*", destination: "./testing/testing2"},
            { source: "./dist", destination: "./testing/testing3" },
            { source: "./dist/**/*.{html,js}", destination: "./testing/testing4" },

--- a/tests/webpack-4/webpack.config.js
+++ b/tests/webpack-4/webpack.config.js
@@ -21,6 +21,7 @@ const plainConfig = {
       onEnd: {
         copy: [
            { source: "./dist/*", destination: "./testing/testing1" },
+           { source: "./dist/*.js", destination: "./testing/testingglob.js" },
            { source: "./dist/**/*", destination: "./testing/testing2"},
            { source: "./dist", destination: "./testing/testing3" },
            { source: "./dist/**/*.{html,js}", destination: "./testing/testing4" },


### PR DESCRIPTION
Resolves https://github.com/gregnb/filemanager-webpack-plugin/issues/27.

For example, copying `{ source: "./dist/*.js", destination: "./testing/testingglob.js" }` should copy the file that matches the glob `"./dist/*.js"` to `"./testing/testingglob.js"` but today it copies as a directory with the glob pattern within `./testing/testingglob.js/*.js`.