### PR TITLE
support exclude specific file or directory while archiving

### DIFF
--- a/src/actions/archive.js
+++ b/src/actions/archive.js
@@ -36,14 +36,15 @@ function archiveAction(command, options) {
 
         // Exclude destination file from archive
         const destFile = path.basename(command.destination);
-        const globOptions = Object.assign({ ignore: destFile }, command.options.globOptions || {});
+        const ignore = (command.options && command.options.ignore || []).concat(destFile);
+        const globOptions = Object.assign({ ignore }, command.options.globOptions || {});
 
         if (isGlob) archive.glob(command.source, globOptions);
         else if (sStats.isFile()) archive.file(command.source, { name: path.basename(command.source) });
         else if (sStats.isDirectory())
           archive.glob('**/*', {
             cwd: command.source,
-            ignore: destFile,
+            ignore,
           });
         archive.finalize().then(() => resolve());
       });


### PR DESCRIPTION
by set options.ignore to support exclude specific file or directory while achiving.
hope this pull request can be allowed. I found some issues is about this feature, and our team is using this plugin and needs this new feature.