### PR TITLE
Add runOnceInWatchMode in options-schema.js

### DIFF
--- a/src/options-schema.js
+++ b/src/options-schema.js
@@ -184,5 +184,10 @@ export default {
       type: 'string',
       description: 'The directory, an absolute path, for resolving files. Defaults to webpack context',
     },
+    runOnceInWatchMode: {
+      type: 'boolean',
+      default: false,
+      description: 'Run tasks only at first compilation in watch mode'
+    }
   },
 };


### PR DESCRIPTION
runOnceInWatchMode mode is not declared in options-schema.js.

Impossible to set this option from webpack.config.js

Related to issue #54 added option "runOnceInWatchMode"

