### PR TITLE
Fix typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Copy individual files or entire directories from a source folder to a destinatio
     options: {
       flat: false,
       preserveTimestamps: true,
-      overwite: true,
+      overwrite: true,
     },
     globOptions: {
       dot: true,


### PR DESCRIPTION
Fix a typo in readme.md file where "overwrite" was misspelled as "overwite".